### PR TITLE
Small typo fixed for hash-bang

### DIFF
--- a/.github/workflows/build/env.sh
+++ b/.github/workflows/build/env.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -e
 shopt -s dotglob
 


### PR DESCRIPTION
Thanks for the partitioned build workflow example.
My editor pointed out this small error and I wanted to let you know